### PR TITLE
npm start should be all lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is Native Application Template by using WP REST API.
 $ git clone https://github.com/hideokamoto/wp-react-native.git
 $ cd wp-react-native
 $ npm install
-$ npm Start
+$ npm start
 
 $ react-native run-ios
 or


### PR DESCRIPTION
I changed `npm Start` to 'npm start`

### Fix or Enhancement?
I wrote some code to...
- [ ]  fix some bug
- [ ]  add some function

### Your Environment
- OS: Write here
- npm version: Write here
- React Native version: Write here

### Your Information
- Your Name:
- Your WebSite Address:
